### PR TITLE
Install stationd and pass-commander via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ These instructions will walk you through the process of setting up this project
 on a development system.
 
 ### Prerequisites
-- [Podman](https://podman.io/docs/installation) 
+- [Podman](https://podman.io/docs/installation)
 - [Podman Compose](https://github.com/containers/podman-compose)
 
 **NOTE:** If you have a non-ARM CPU you will need

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -5,6 +5,8 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
+        python3 \
+        python3-pip \
         sudo
 
 ARG RPIIG_GIT_SHA=4492e0ffd45fa4f1aa73924b20270bb818b54286

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -2,10 +2,11 @@ FROM debian:bookworm
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
+        build-essential \
         ca-certificates \
         curl \
         git \
-        python3 \
+        python3-dev \
         python3-pip \
         sudo
 

--- a/uniclogs/meta/customizations.yaml
+++ b/uniclogs/meta/customizations.yaml
@@ -10,5 +10,5 @@ mmdebstrap:
     - python3-pip
   install-recommends: false
   customize-hooks:
-    - git clone --recurse-submodules https://github.com/uniclogs/uniclogs-stationd.git $1/home/uniclogs/uniclogs-stationd
+    - pip3 download --dest $1/home/uniclogs/uniclogs-stationd uniclogs-stationd
     - git clone https://github.com/uniclogs/uniclogs-pass_commander.git $1/home/uniclogs/uniclogs-pass_commander

--- a/uniclogs/meta/customizations.yaml
+++ b/uniclogs/meta/customizations.yaml
@@ -10,6 +10,5 @@ mmdebstrap:
     - python3-pip
   install-recommends: false
   customize-hooks:
-    # TODO: Figure out a way to do this without --break-system-packages
     - pip3 install uniclogs-stationd --break-system-packages
     - git clone https://github.com/uniclogs/uniclogs-pass_commander.git $1/home/uniclogs/uniclogs-pass_commander

--- a/uniclogs/meta/customizations.yaml
+++ b/uniclogs/meta/customizations.yaml
@@ -2,7 +2,6 @@
 name: customizations
 mmdebstrap:
   packages:
-    - git
     - i2c-tools
     - libhamlib-utils
     - netcat-openbsd
@@ -11,4 +10,4 @@ mmdebstrap:
   install-recommends: false
   customize-hooks:
     - pip3 install uniclogs-stationd --break-system-packages
-    - git clone https://github.com/uniclogs/uniclogs-pass_commander.git $1/home/uniclogs/uniclogs-pass_commander
+    - pip3 install uniclogs-pass-commander --break-system-packages

--- a/uniclogs/meta/customizations.yaml
+++ b/uniclogs/meta/customizations.yaml
@@ -10,5 +10,6 @@ mmdebstrap:
     - python3-pip
   install-recommends: false
   customize-hooks:
-    - pip3 download --dest $1/home/uniclogs/uniclogs-stationd uniclogs-stationd
+    # TODO: Figure out a way to do this without --break-system-packages
+    - pip3 install uniclogs-stationd --break-system-packages
     - git clone https://github.com/uniclogs/uniclogs-pass_commander.git $1/home/uniclogs/uniclogs-pass_commander


### PR DESCRIPTION
This work changes the way that the image builder accesses the uniclogs-stationd and uniclogs-pass-commander library. Instead of using git to pull uniclogs-stationd down from Github, it will now use pip to install it (from our pypi.org repo which is where the project builds and "deploys" to).