### PR TITLE
Fix: Linux hosts cannot build images

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To perform manual generation, you'll need access to the container directly. You
 can get a shell inside the container by running the following command:
 
 ```sh
-podman compose run --build rpi_imagegen bash
+podman compose build rpi_imagegen bash
 ```
 
 If running on a non-ARM host, from within the container, run the following

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To perform manual generation, you'll need access to the container directly. You
 can get a shell inside the container by running the following command:
 
 ```sh
-podman compose build rpi_imagegen bash
+podman compose run rpi_imagegen bash
 ```
 
 If running on a non-ARM host, from within the container, run the following

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,6 @@ services:
     image: rpi-imagegen:latest
     working_dir: /home/imagegen/rpi-image-gen
     volumes:
-      - ./build:/home/imagegen/build
-      - ./scripts:/home/imagegen/scripts
-      - ./uniclogs:/home/imagegen/uniclogs
+      - ./build:/home/imagegen/build:z
+      - ./scripts:/home/imagegen/scripts:ro
+      - ./uniclogs:/home/imagegen/uniclogs:ro

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -16,17 +16,15 @@ RUN curl -L -o rpi-image-gen.tar.gz https://github.com/raspberrypi/rpi-image-gen
     && mv rpi-image-gen-${RPIIG_GIT_SHA} /rpi-image-gen \
     && rm rpi-image-gen.tar.gz
 
-RUN <<EOF
-arch=$(uname -m);
-if [ "$arch" != "aarch64" ] || [ "$arch" != "arm64" ]; then
-    apt-get install --no-install-recommends -y qemu-user-static;
+RUN arch=$(uname -m) \
     # the binfmt_misc check in install_deps.sh will fail since it is not
     # mounted; suppress the error.
-    /rpi-image-gen/install_deps.sh || true;
-else
-    /rpi-image-gen/install_deps.sh;
-fi
-EOF
+    && if [ "$arch" != "aarch64" ] || [ "$arch" != "arm64" ]; then \
+        apt-get install --no-install-recommends -y qemu-user-static \
+        && /rpi-image-gen/install_deps.sh || true; \
+    else \
+        /rpi-image-gen/install_deps.sh; \
+    fi
 
 ENV USER=imagegen
 RUN useradd -u 4000 -ms /bin/bash "$USER" \

--- a/scripts/build-env.sh
+++ b/scripts/build-env.sh
@@ -18,9 +18,15 @@ main() {
     PROJECT_ROOT="$SCRIPT_DIR/.."
 
     cd "$PROJECT_ROOT"
-    exec podman compose run --build rpi_imagegen bash -c "
-        /home/imagegen/scripts/generate-image.sh
-    "
+
+    sudo podman run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes -c yes
+    sudo podman build -t rpi-imagegen:latest -f container/Containerfile .
+
+    mkdir -p "$PROJECT_ROOT/build"
+    sudo chmod 777 "$PROJECT_ROOT/build"
+
+    print_info "Running image generation (requires sudo for privileged operations) ..."
+    exec sudo podman compose run --rm rpi_imagegen bash -c "/home/imagegen/scripts/generate-image.sh"
 }
 
 main "$@"

--- a/scripts/generate-image.sh
+++ b/scripts/generate-image.sh
@@ -25,15 +25,31 @@ print_error() {
 }
 
 mount_binfmt_misc() {
+    if [ -f /proc/sys/fs/binfmt_misc/status ] 2>/dev/null;
+    then
+        print_info "binfmt_misc is already available."
+        return 0
+    fi
+
     print_info "Mounting binfmt_misc ..."
     print_warning "Enter the imagegen user's password (imagegen)!"
 
-    if sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc;
+    mount_output=$(sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc 2>&1)
+    mount_status=$?
+
+    if [ $mount_status -eq 0 ];
     then
         print_success "binfmt_misc mounted successfully."
     else
-        print_error "Failed to mount binfmt_misc."
-        exit 1
+        if echo "$mount_output" | grep -iq "already mounted" || [ -f /proc/sys/fs/binfmt_misc/status ];
+        then
+            print_info "binfmt_misc is already mounted."
+            return 0
+        else
+            print_error "Failed to mount binfmt_misc."
+            echo "$mount_output"
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
This work fixes some minor issues when attempting to run image generation in a podman container on a linux host.  This has also been tested on macOS ✅ 

This should also fix https://github.com/uniclogs/uniclogs-linux/issues/14