### PR TITLE
Fix: IP address not being assigned on first boot

### DIFF
--- a/uniclogs/meta/customizations.yaml
+++ b/uniclogs/meta/customizations.yaml
@@ -4,16 +4,20 @@ mmdebstrap:
   packages:
     - bc
     - build-essential
+    - dbus
     - fdisk
     - gpiod
     - i2c-tools
+    - iproute2
     - libgpiod-dev
     - libhamlib-utils
     - netcat-openbsd
+    - net-tools
     - python3-dev
     - python3-hamlib
     - python3-libgpiod
     - python3-pip
+    - vim
   install-recommends: false
   customize-hooks:
     - chroot $1 raspi-config nonint do_i2c 0
@@ -23,5 +27,5 @@ mmdebstrap:
     - cat /home/imagegen/uniclogs/misc/append-to-boot-config.txt >> $1/boot/firmware/config.txt
     - chroot $1 chown -R uniclogs:uniclogs /home/uniclogs/bin
     - chroot $1 usermod -a -G gpio uniclogs
-    - chroot $1 systemctl enable rotctld.service stationd.service
+    - chroot $1 systemctl enable rotctld.service stationd.service systemd-networkd.service
     - chroot $1 sh -c 'echo RuntimeWatchdogSec=5 >> /etc/systemd/system.conf'

--- a/uniclogs/overlay/etc/systemd/network/01-eth0.network
+++ b/uniclogs/overlay/etc/systemd/network/01-eth0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=en* eth*
+
+[Network]
+Address=10.10.1.5/24


### PR DESCRIPTION
This work sets the static IP on the station pi to our desired address, and adds a couple more useful libraries that were not present on the image (like vim).